### PR TITLE
moneronodejs -> monerojs, update examples, and add note about tests (and tests being the best examples)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ var daemonRPC = new Monero.daemonRPC({ autoconnect: true })
 ```js
 // const daemonRPC = new Monero.daemonRPC().then(...).catch(...); // Connect with defaults
 // const daemonRPC = new Monero.daemonRPC('127.0.0.1', 28081, 'user', 'pass', 'http').then(...).catch(...); // Example of passing in parameters
-// const daemonRPC = new Monero.daemonRPC({ port: 28081, protocol: 'https').then(...).catch(...); // Parameters can be passed in as an object/dictionary
+// const daemonRPC = new Monero.daemonRPC({ port: 28081, protocol: 'https' }).then(...).catch(...); // Parameters can be passed in as an object/dictionary
 const daemonRPC = new Monero.daemonRPC() // Connect with defaults
 .then(daemon => {
   daemonRPC = daemon; // Store daemon interface in global variable
@@ -60,7 +60,7 @@ const daemonRPC = new Monero.daemonRPC() // Connect with defaults
 
 ```js
 // const walletRPC = new Monero.walletRPC('127.0.0.1', 28083, 'user', 'pass', 'http').then(...).catch(...); // Example of passing in parameters
-// const walletRPC = new Monero.walletRPC({ port: 28083, protocol: 'https').then(...).catch(...); // Parameters can be passed in as an object/dictionary
+// const walletRPC = new Monero.walletRPC({ port: 28083, protocol: 'https' }).then(...).catch(...); // Parameters can be passed in as an object/dictionary
 // const walletRPC = new Monero.walletRPC({ autoconnect: true }).then(...).catch(...); // Autoconnect
 const walletRPC = new Monero.walletRPC() // Connect with defaults
 .then(wallet => {

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ JSON-RPC interfaces and their methods are wrapped in promises.
 #### Autoconnect to Monero daemon (`monerod`)
 
 ```js
-const Monero = require('moneronodejs');
+const Monero = require('monerojs');
 
 var daemonRPC = new Monero.daemonRPC({ autoconnect: true })
 .then((daemon) => {

--- a/README.md
+++ b/README.md
@@ -13,9 +13,13 @@ npm install monerojs
 ```
 *`--save` optional*
 
+## Testing
+
+Install dependencies (`npm install`) and then run `npm test`
+
 ## Usage
 
-JSON-RPC interfaces and their methods are wrapped in promises.
+JSON-RPC interfaces and their methods are wrapped in promises.  Much more exhaustive examples can be found in the [tests](https://github.com/monerojs/monerojs/blob/dev/test/index_test.js)
 
 #### Autoconnect to Monero daemon (`monerod`)
 

--- a/example.js
+++ b/example.js
@@ -1,4 +1,4 @@
-// const Monero = require('moneronodejs'); // Used when accessing class outside of library
+// const Monero = require('monerojs'); // Used when accessing class outside of library
 const Monero = require('./index.js'); // Used when accessing class from within library
 
 // Autoconnect asynchronously (with a promise)

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 /**
- * moneronodejs
+ * monerojs
  * 
  * ES6 JavaScript Monero library 
- * https://github.com/sneurlax/moneronodejs
+ * https://github.com/monerojs/monerojs
  * 
  * @author     sneurlax <sneurlax@gmail.com> (https://github.com/sneurlax)
  * @copyright  2018

--- a/lib/cryptonote.js
+++ b/lib/cryptonote.js
@@ -1,9 +1,9 @@
 /**
  * 
- * moneronodejs/cryptonote
+ * monerojs/cryptonote
  * 
  * A class for making calls to Monero's RPC API using Node.js
- * https://github.com/monero-integrations/moneronodejs
+ * https://github.com/monerojs/monerojs
  *
  * Using work from
  *   CryptoChangements <bW9uZXJv@gmail.com> (https://github.com/cryptochangements34)

--- a/lib/daemonRPC.js
+++ b/lib/daemonRPC.js
@@ -1,8 +1,8 @@
 /**
- * moneronodejs/daemonRPC
+ * monerojs/daemonRPC
  * 
  * A class for making calls to a Monero daemon's RPC API using Node.js
- * https://github.com/sneurlax/moneronodejs
+ * https://github.com/monerojs/monerojs
  * 
  * @author     sneurlax <sneurlax@gmail.com> (https://github.com/sneurlax)
  * @copyright  2018

--- a/lib/walletRPC.js
+++ b/lib/walletRPC.js
@@ -1,8 +1,8 @@
 /**
- * moneronodejs/walletRPC
+ * monerojs/walletRPC
  * 
  * A class for making calls to monero-wallet-rpc using Node.js
- * https://github.com/monero-integrations/moneronodejs
+ * https://github.com/monerojs/monerojs
  * 
  * @author     sneurlax <sneurlax@gmail.com> (https://github.com/sneurlax)
  * @copyright  2018


### PR DESCRIPTION
See the title, but:

 - Several references to moneronodejs have been changed to monerojs
 - The examples were updated to fix a missing curly bracket
 - The readme was updated to mention how tests are run (`npm test`) and that the tests are the best examples of usage